### PR TITLE
Refactor DexiNet while maintaining existing structure.

### DIFF
--- a/DexiNed-Pytorch/model.py
+++ b/DexiNed-Pytorch/model.py
@@ -32,17 +32,11 @@ class _DenseBlock(nn.Sequential):
             input_features = out_features
 
 class UpConvBlock(nn.Module):
-    def __init__(self, in_features, up_scale, mode='deconv'):
+    def __init__(self, in_features, up_scale):
         super(UpConvBlock, self).__init__()
-        self.up_factor = 2
         self.constant_features = 16
 
-        layers = None
-        if mode == 'deconv':
-            layers = self.make_deconv_layers(in_features, up_scale)
-        elif mode == 'pixel_shuffle':
-            layers = self.make_pixel_shuffle_layers(in_features, up_scale)
-        assert layers is not None, layers
+        layers = self.make_deconv_layers(in_features, up_scale)
         self.features = nn.Sequential(*layers)
 
     def make_deconv_layers(self, in_features, up_scale):
@@ -54,19 +48,6 @@ class UpConvBlock(nn.Module):
             layers.append(nn.ReLU(inplace=True))
             layers.append(nn.ConvTranspose2d(
                 out_features, out_features, kernel_size, stride=2))
-            in_features = out_features
-        return layers
-
-    def make_pixel_shuffle_layers(self, in_features, up_scale):
-        layers = []
-        for i in range(up_scale):
-            kernel_size = 2 ** (i + 1)
-            out_features = self.compute_out_features(i, up_scale)
-            in_features = int(in_features / (self.up_factor ** 2))
-            layers.append(nn.PixelShuffle(self.up_factor))
-            layers.append(nn.Conv2d(in_features, out_features, 1))
-            if i < up_scale:
-                layers.append(nn.ReLU(inplace=True))
             in_features = out_features
         return layers
 

--- a/DexiNed-Pytorch/model.py
+++ b/DexiNed-Pytorch/model.py
@@ -1,24 +1,26 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from collections import OrderedDict
 
-class _DenseLayer(nn.Sequential):
+class _DenseLayer(nn.Module):
     def __init__(self, input_features, out_features):
         super(_DenseLayer, self).__init__()
         # self.add_module('relu2', nn.ReLU(inplace=True)),
-        self.add_module('conv1', nn.Conv2d(input_features, out_features,
-                        kernel_size=1, stride=1, bias=True)),
-        self.add_module('norm1', nn.BatchNorm2d(out_features)),
-        self.add_module('relu1', nn.ReLU(inplace=True)),
-        self.add_module('conv2', nn.Conv2d(out_features, out_features,
-                        kernel_size=3, stride=1, padding=1, bias=True)),
-        self.add_module('norm2', nn.BatchNorm2d(out_features))
+        self.layers = nn.Sequential(OrderedDict([
+            ('conv1', nn.Conv2d(input_features, out_features,
+                                kernel_size=1, stride=1, bias=True)),
+            ('norm1', nn.BatchNorm2d(out_features)),
+            ('relu1', nn.ReLU(inplace=True)),
+            ('conv2', nn.Conv2d(out_features, out_features,
+                                kernel_size=3, stride=1, padding=1, bias=True)),
+            ('norm2', nn.BatchNorm2d(out_features))]))
         # double check the norm1 comment if necessary and put norm after conv2
 
     def forward(self, x):
         x1, x2 = x
         # maybe I should put here a RELU
-        new_features = super(_DenseLayer, self).forward(x1) # F.relu()
+        new_features = self.layers(x1) # F.relu()
         return 0.5 * (new_features + x2), x2
 
 class _DenseBlock(nn.Sequential):
@@ -198,7 +200,6 @@ class DexiNet(nn.Module):
         # return results
         results.append(block_cat)
         return results
-
 
 if __name__ == '__main__':
     batch_size = 8


### PR DESCRIPTION
`super(_DenseLayer, self)` returns `nn.Sequence`, so this code uses it
to eliminate an awkward `.forward()` call.

This PR is a more direct port than #18.

The downside to both is they require retraining from scratch.